### PR TITLE
Support 4-bit LoRA workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,42 @@ python -m src.finetune_vibevoice_lora \
 ```
 
 
+### Optional: 4-bit LoRA loading
+
+The training entrypoint can quantize the base language model to 4-bit weights while keeping LoRA adapters, diffusion heads, and connectors in floating point. This reduces memory requirements for experimentation.
+
+1. Install the quantization dependencies:
+
+   ```bash
+   pip install bitsandbytes accelerate
+   ```
+
+2. Launch training with the `--load_in_4bit` flag. All other arguments remain the same:
+
+   ```bash
+   python -m src.finetune_vibevoice_lora \
+     --model_name_or_path aoi-ot/VibeVoice-Large \
+     --processor_name_or_path src/vibevoice/processor \
+     --train_jsonl prompts.jsonl \
+     --text_column_name text \
+     --audio_column_name audio \
+     --output_dir output_4bit_lora \
+     --per_device_train_batch_size 4 \
+     --gradient_accumulation_steps 32 \
+     --learning_rate 2.5e-5 \
+     --num_train_epochs 1 \
+     --logging_steps 10 \
+     --save_steps 1000 \
+     --bf16 True \
+     --do_train \
+     --remove_unused_columns False \
+     --lora_target_modules q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj \
+     --load_in_4bit
+   ```
+
+The adapters are saved under `output_4bit_lora/lora/` exactly like full-precision runs, making it simple to swap between precision modes.
+
+
 ### JSONL format:
 
   

--- a/tests/test_quantized_integration.py
+++ b/tests/test_quantized_integration.py
@@ -1,0 +1,111 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+from peft import LoraConfig, get_peft_model
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "vibevoice" not in sys.modules:
+    import types
+
+    vibevoice_pkg = types.ModuleType("vibevoice")
+    modular_pkg = types.ModuleType("vibevoice.modular")
+    modeling_pkg = types.ModuleType("vibevoice.modular.modeling_vibevoice")
+    configuration_pkg = types.ModuleType("vibevoice.modular.configuration_vibevoice")
+    processor_pkg = types.ModuleType("vibevoice.processor")
+    processor_subpkg = types.ModuleType("vibevoice.processor.vibevoice_processor")
+    data_pkg = types.ModuleType("data_vibevoice")
+
+    class _StubModel(nn.Module):
+        pass
+
+    class _StubConfig:
+        pass
+
+    class _StubProcessor:
+        tokenizer = None
+
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):  # pragma: no cover - test shim
+            return cls()
+
+    class _StubDataset:
+        pass
+
+    class _StubCollator:
+        pass
+
+    modeling_pkg.VibeVoiceForConditionalGeneration = _StubModel
+    configuration_pkg.VibeVoiceConfig = _StubConfig
+    processor_subpkg.VibeVoiceProcessor = _StubProcessor
+    data_pkg.VibeVoiceDataset = _StubDataset
+    data_pkg.VibeVoiceCollator = _StubCollator
+
+    sys.modules["vibevoice"] = vibevoice_pkg
+    sys.modules["vibevoice.modular"] = modular_pkg
+    sys.modules["vibevoice.modular.modeling_vibevoice"] = modeling_pkg
+    sys.modules["vibevoice.modular.configuration_vibevoice"] = configuration_pkg
+    sys.modules["vibevoice.processor"] = processor_pkg
+    sys.modules["vibevoice.processor.vibevoice_processor"] = processor_subpkg
+    sys.modules["data_vibevoice"] = data_pkg
+
+from src.finetune_vibevoice_lora import (
+    _cast_module_to_dtype,
+    _ensure_lora_params_trainable,
+    _safe_save_state_dict,
+)
+
+
+@pytest.mark.skipif("CI" in os.environ, reason="Quantized smoke test is lightweight but optional for CI runs.")
+def test_lora_requires_grad_and_fp_modules(tmp_path):
+    bitsandbytes = pytest.importorskip("bitsandbytes")
+
+    class DummyLanguageModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = bitsandbytes.nn.Linear4bit(8, 8, bias=False)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    class DummyCore(nn.Module):
+        def __init__(self):
+            super().__init__()
+            lora_cfg = LoraConfig(r=4, lora_alpha=16, lora_dropout=0.0, bias="none", target_modules=["linear"])
+            self.language_model = get_peft_model(DummyLanguageModel(), lora_cfg)
+            self.prediction_head = nn.Linear(8, 8)
+            self.acoustic_connector = nn.Linear(4, 4)
+            self.semantic_connector = nn.Linear(4, 4)
+
+    class DummyWrapper(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = DummyCore()
+
+    dummy = DummyWrapper()
+
+    for _, param in dummy.named_parameters():
+        param.requires_grad = False
+
+    _ensure_lora_params_trainable(dummy)
+
+    lora_params = {name: p for name, p in dummy.named_parameters() if "lora_" in name}
+    assert lora_params, "LoRA parameters should be present in the dummy language model"
+    assert all(param.requires_grad for param in lora_params.values())
+
+    _cast_module_to_dtype(dummy.model.prediction_head, torch.float16, "prediction_head")
+    assert all(param.dtype == torch.float16 for param in dummy.model.prediction_head.parameters())
+
+    save_dir = tmp_path / "check"
+    _safe_save_state_dict(dummy.model.language_model, str(save_dir), "language_model.bin", "dummy language model")
+    saved_file = save_dir / "language_model.bin"
+    assert saved_file.exists()
+    state = torch.load(saved_file)
+    assert any("lora_" in key for key in state.keys())


### PR DESCRIPTION
## Summary
- add a --load_in_4bit option that loads the base model with bitsandbytes while keeping LoRA adapters in floating precision
- harden the freeze/unfreeze logic and saving routines so LoRA parameters remain trainable and quantized modules skip unsupported full-state saves
- document 4-bit usage and add a pytest smoke test that exercises the quantized path with dummy weights

## Testing
- pytest tests/test_quantized_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68da2412c1e88322b4de3d96fa10fd6b